### PR TITLE
fix(dashboard): resolve task board status filtering and horizontal scroll

### DIFF
--- a/web/src/components/Dashboard.tsx
+++ b/web/src/components/Dashboard.tsx
@@ -99,8 +99,8 @@ export default function Dashboard() {
         query = query.eq('project_id', filterProject)
       }
 
-      // Server-side status filtering
-      if (filterStatus) {
+      // Server-side status filtering (skip when grouping by status to show all tasks)
+      if (filterStatus && groupBy !== 'status') {
         query = query.eq('status', filterStatus)
       }
 
@@ -114,7 +114,7 @@ export default function Dashboard() {
     } catch (error) {
       console.error('Error loading tasks:', error)
     }
-  }, [supabase, searchTerm, filterProject, filterStatus])
+  }, [supabase, searchTerm, filterProject, filterStatus, groupBy])
 
   // Separate function to load Focus Mode tasks with server-side filtering
   const loadFocusModeFilteredTasks = useCallback(async () => {

--- a/web/src/components/KanbanView.tsx
+++ b/web/src/components/KanbanView.tsx
@@ -79,8 +79,8 @@ export default function KanbanView({
   const headerPadding = compact ? 'p-2' : 'p-3'
 
   return (
-    <div className="h-full bg-background overflow-auto">
-      <div className="flex gap-5 h-full p-5">
+    <div className="h-full bg-background overflow-x-auto overflow-y-hidden">
+      <div className="flex gap-5 h-full p-5 min-w-fit">
         {columns.map((column) => (
           <div
             key={column.id}


### PR DESCRIPTION
## Summary

This PR resolves two critical issues with the dashboard task board functionality:

1. **Task Status Filtering Bug**: Fixed tasks appearing only in "Todo" column when grouped by status
2. **Horizontal Scroll Enhancement**: Added proper horizontal scrolling for kanban boards with many columns

## Changes

### 🔧 Dashboard.tsx
- **Fixed server-side status filtering logic** to skip status filter when `groupBy` is set to `'status'`
- **Updated useCallback dependencies** to include `groupBy` parameter for proper re-rendering
- **Root cause**: Status filter was being applied even when viewing tasks grouped by status, preventing proper distribution across columns

### 🎨 KanbanView.tsx  
- **Enhanced horizontal overflow handling** with `overflow-x-auto overflow-y-hidden`
- **Added minimum width constraint** with `min-w-fit` to prevent content wrapping
- **Improved scrolling behavior** for dashboards with multiple columns

## Technical Details

**Before**: When `groupBy === 'status'`, the server query would still apply `filterStatus`, causing all tasks to be filtered to a single status instead of showing the complete distribution.

**After**: Status filtering is bypassed when grouping by status, allowing proper task distribution:
```typescript
// Skip status filter when grouping by status to show all tasks
if (filterStatus && groupBy \!== 'status') {
  query = query.eq('status', filterStatus)
}
```

## Test Plan

- [x] **Build verification**: `npm run build` passes successfully  
- [x] **Lint verification**: `npm run lint` passes with no errors
- [x] **TypeScript compilation**: No type errors detected
- [ ] **Manual testing**: Verify tasks distribute correctly across status columns
- [ ] **Scrolling test**: Confirm horizontal scrolling works with multiple columns

## Files Modified

- `web/src/components/Dashboard.tsx` (3 lines changed)
- `web/src/components/KanbanView.tsx` (2 lines changed)

**Total**: 2 files changed, 5 insertions(+), 5 deletions(-)

🤖 Generated with [Claude Code](https://claude.ai/code)